### PR TITLE
bau: Use an environment variable to specify public binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
   - oraclejdk8
   - oraclejdk9
@@ -6,6 +8,3 @@ jdk:
 matrix:
   allow_failures:
   - jdk: oraclejdk9
-before_install:
-# this is a hack, so PR builds can be tested in travis
-  - perl -i -0pe 's/maven[\s\{]+[^\{\}]*\}/maven { url \"https:\/\/build.shibboleth.net\/nexus\/content\/groups\/public\" \n url \"https:\/\/repo1.maven.org\/maven2\" \n jcenter() }/gms' build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,17 @@ apply from: 'publish.gradle'
 apply plugin: 'java'
 
 repositories {
-  maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+  if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+    logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+    maven {
+      url 'https://build.shibboleth.net/nexus/content/groups/public'
+      url 'https://repo1.maven.org/maven2'
+      jcenter()
+    }
+  }
+  else {
+    maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
This is more elegant than the perl hack we were using before. Should
make it easier to build locally when you're not in the GDS VPN.