### PR TITLE
BAU Upgrade bintray plugin to 1.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply from: 'publish.gradle'
 apply plugin: 'java'
 


### PR DESCRIPTION
The most recent builds of this repo have failed to publish to bintray
due to an error: `Unable to upload files: Maven group, artifact or
version defined in the pom file do not match the file path`

Other people have had a similar issues which appear to be resolved by
bumping to 1.8.1.