### PR TITLE
BAU Upgrade Guava to 24.1.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.guava:guava:18.0',
+  compile 'com.google.guava:guava:24.1.1-jre',
           'commons-io:commons-io:2.4'
 }
 


### PR DESCRIPTION
The current version 18.0 is vulnerable to [CVE-2018-10237](https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236)