### PR TITLE
HUB-866: Publish verify-dev-pki to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
-plugins { id "com.jfrog.bintray" version "1.8.4" }
+plugins { 
+    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+}
 apply from: 'publish.gradle'
 apply plugin: 'java-library'
 
@@ -17,5 +19,9 @@ dependencies {
                   'commons-io:commons-io:2.4'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    withJavadocJar()
+    withSourcesJar()
+}

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,37 +1,71 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java-library'
+apply plugin: 'java'
+apply plugin: 'signing'
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-def buildVersion = "1.2.0-${System.getenv('BUILD_NUMBER') ?: 'SNAPSHOT'}"
+def buildVersion = "2.0.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+group = "uk.gov.ida"
+version = "$buildVersion"
+archivesBaseName = "verify-dev-pki"
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId = "uk.gov.ida"
-            artifactId = "ida-dev-pki"
-            version = "$buildVersion"
-
             from components.java
+            pom {
+                name = 'Verify Dev PKI'
+                packaging = 'jar'
+                description = 'This repo contains keys and certificates for use in integration tests'
+                url = 'https://github.com/alphagov/verify-dev-pki'
+                artifactId = 'verify-dev-pki'
+
+                scm {
+                    url = 'https://github.com/alphagov/verify-dev-pki'
+                    connection = 'scm:git:git://github.com/alphagov/verify-dev-pki.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:alphagov/verify-dev-pki.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'MIT Licence'
+                        url = 'https://github.com/alphagov/verify-dev-pki/blob/master/LICENCE'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        name = 'GDS Developers'
+                    }
+                }
+            }
         }
     }
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['mavenJava']
-    publish = true
-    pkg {
-        repo = 'maven-test'
-        name = 'ida-dev-pki'
-        userOrg = 'alphagov'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/alphagov/verify-dev-pki.git'
-        version {
-            name = "$buildVersion"
+nexusPublishing {
+    useStaging = true
+    repositories {
+        sonatype {
+            // because we registered in Sonatype after 24 Feb 2021, we provide these URIs
+            // see: https://github.com/gradle-nexus/publish-plugin/blob/master/README.md
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
         }
     }
+}
+
+signing {
+    useInMemoryPgpKeys(
+        System.getenv("MAVEN_CENTRAL_SIGNING_KEY"),
+        System.getenv("MAVEN_CENTRAL_SIGNING_KEY_PASSWORD")
+    )
+    sign publishing.publications
 }


### PR DESCRIPTION
Following these docs:
https://verify-team-manual.cloudapps.digital/documentation/support/third-line/library_publishing.html