### PR TITLE
HUB-907: Replace jcenter with maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java-library'
 repositories {
   if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
     logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-    jcenter()
+    mavenCentral()
   }
   else {
     maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }


### PR DESCRIPTION
Jcenter is going away. This replaces it with maven central which isn't.