### PR TITLE
HUB-916 revert artifact id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ deploy/perf_graphs
 *.log
 *~
 *.swp
+.vscode

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,7 +11,7 @@ task sourceJar(type: Jar) {
 def buildVersion = "2.0.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 group = "uk.gov.ida"
 version = "$buildVersion"
-archivesBaseName = "verify-dev-pki"
+archivesBaseName = "ida-dev-pki"
 
 publishing {
     publications {
@@ -22,7 +22,7 @@ publishing {
                 packaging = 'jar'
                 description = 'This repo contains keys and certificates for use in integration tests'
                 url = 'https://github.com/alphagov/verify-dev-pki'
-                artifactId = 'verify-dev-pki'
+                artifactId = 'ida-dev-pki'
 
                 scm {
                     url = 'https://github.com/alphagov/verify-dev-pki'


### PR DESCRIPTION
When publishing to Maven Central, we set the artifact id for Verify dev PKI to `verify-dev-pki` but it should have remained `ida-dev-pki` - this change reverts the artifact id only.