### PR TITLE
BAU: Fix UNCHAINED_PRIVATE_KEY

### DIFF
--- a/src/main/java/uk/gov/ida/saml/core/test/TestCertificateStrings.java
+++ b/src/main/java/uk/gov/ida/saml/core/test/TestCertificateStrings.java
@@ -138,7 +138,27 @@ public final class TestCertificateStrings {
 
 
     public static final String UNCHAINED_PRIVATE_KEY =
-            "MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALGtlH968fIt6cYokQ8YWcvcNVfENKrkE3//yBSXI2IbUj6UVQpCZjD0bMShat4DPC+yYSw4mXo7XxvfkRiYLxzfWgKq8xL/4wjpBC457kmr2G8qujm7egoRxIS+SCQQtU/vQqXGRlXnlIZAuIZpGxlfJuQSz0pBQaZh4W4WBhGDAgMBAAECgYEAiYmPePsHzOtjmiQO3fuAj0D//deA2YRB4AR0shOorSnvCUgzaASsLFsY00EMg51Herh/ZgbOL4NEBUSTgdFULaACPQlAcPZc/BkKlP6n1Xz74KdtFKW8kxd0SoVxlL1WfHKP2KCs0IYMRtsWZdfcnF2ybu1sd0dHqL74BREo++kCQQDdRh39IDyD0QgQllmbpWTHsoU5BTAPVohYEx+9e2lTnkP2rhYIg3rTIQfaa0dRB4AO74nsyX7rDPtr1bziqj7VAkEAzY/1owrdby1v8rDx9LJ4cZeICnSIEje3vXC7e0qPqNArKAx1dTgt8x3mciTaDqcoz69Srks/OXzssKf+ZuKq9wJBAK9C61vj3aq2tYGV5NHgdeuqndTlJATyEDpao2hMyMc/cyt/BdqmcXGrFvJMyIcIvsiVuJRBoPKCLN5jxCFwoSUCQD2CKAQDSkLsG6VI4P1RMcz7hI9sUxLwbSBYTSEVLGtc7qzrHXJXvxgSCFR7RmxABGwwj9LrXR28ja5Gdk8e3/0CQB7pVgitNX6wSx5zB3fOasg7wgpOBsvQCPqlqYLG3+b9mPgZOg2vz97NeQJJQ3Ro0y9fHHo7Y0BCwGiPcBYVeU4=+XXr82WshZuMBs14ab96yzsKutbqNppLMl8uG/BLuHYkeuFRXcTiWr2x+aUKe2DYj6867asb4lOmRrA4HWulZ7ginvUZZk+6h3fQxxyIrv7rEvGPEmUjnAgMBAAECgYB21O0Bj3yt+6mitK8lVvAer8E3uZpg4do0L2ULU5Cs3wasnvjgHL4PmN31IpGUnuzE7B4n3Yvso9nlTve2utXZ8F1FMRohGOaov9QdIFmko7fHJryo7L6piW6RJsE06tfsCFXyfCrzVM/mqtCqbKRETA8p82rpjUpbit66gg1twQJBAPW1CCXM/TmrJbrqQsoig3HL5JFXa/BT0WskWm34FJbTqqwBEBTMr0ZTLouc5yBNDoXc2cLcVIcZKXLQeDMUMtkCQQDxoqb4p40Y/RBdhDwG7aL1hyRIKGBiKZgqP24KhoVHxGz43UFyIgloz9rpmjfI2qyh6LkTXdnerpyfwZ0xKIG/AkBmbSkQWPvW5nm8CZv+F5UkAxMtY3wjm01ZlLX90cUDewlS2r6RbSJD9rkYijfvRzAerYo5qQ+zodGdgzoYUPtBAkEAgrgZWB9cZ45P0id9Sco5BFatvBOLwM77sK9L2onXhHGw+hjIFPRw3rDDnuh9ET2rcpOxu9ZjzOHtfUeCwFtHhQJAFwBFPDIfejC+6Wids24B1uD8xqWF8y6EEDH7zH2RIj4xtJW+pVG1l3XVpvXMPkId9NTIdHDwpolqg+/cb1WKzA==";
+            "MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBALGtlH968fIt6cYokQ8YWcvcNVfENKrk" +
+                "E3//yBSXI2IbUj6UVQpCZjD0bMShat4DPC+yYSw4mXo7XxvfkRiYLxzfWgKq8xL/4wjpBC457kmr2G8q" +
+                "ujm7egoRxIS+SCQQtU/vQqXGRlXnlIZAuIZpGxlfJuQSz0pBQaZh4W4WBhGDAgMBAAECgYEAiYmPePsH" +
+                "zOtjmiQO3fuAj0D//deA2YRB4AR0shOorSnvCUgzaASsLFsY00EMg51Herh/ZgbOL4NEBUSTgdFULaAC" +
+                "PQlAcPZc/BkKlP6n1Xz74KdtFKW8kxd0SoVxlL1WfHKP2KCs0IYMRtsWZdfcnF2ybu1sd0dHqL74BREo" +
+                "++kCQQDdRh39IDyD0QgQllmbpWTHsoU5BTAPVohYEx+9e2lTnkP2rhYIg3rTIQfaa0dRB4AO74nsyX7r" +
+                "DPtr1bziqj7VAkEAzY/1owrdby1v8rDx9LJ4cZeICnSIEje3vXC7e0qPqNArKAx1dTgt8x3mciTaDqco" +
+                "z69Srks/OXzssKf+ZuKq9wJBAK9C61vj3aq2tYGV5NHgdeuqndTlJATyEDpao2hMyMc/cyt/BdqmcXGr" +
+                "FvJMyIcIvsiVuJRBoPKCLN5jxCFwoSUCQD2CKAQDSkLsG6VI4P1RMcz7hI9sUxLwbSBYTSEVLGtc7qzr" +
+                "HXJXvxgSCFR7RmxABGwwj9LrXR28ja5Gdk8e3/0CQB7pVgitNX6wSx5zB3fOasg7wgpOBsvQCPqlqYLG" +
+                "3+b9mPgZOg2vz97NeQJJQ3Ro0y9fHHo7Y0BCwGiPcBYVeU75devzZayFm4wGzXhpv3rLOwq61uo2mksy" +
+                "Xy4b8Eu4diR64VFdxOJavbH5pQp7YNiPrzrtqxviU6ZGsDgda6VnuCKe9RlmT7qHd9DHHIiu/usS8Y8S" +
+                "ZSOcCAwEAAQKBgHbU7QGPfK37qaK0ryVW8B6vwTe5mmDh2jQvZQtTkKzfBqye+OAcvg+Y3fUikZSe7MT" +
+                "sHifdi+yj2eVO97a61dnwXUUxGiEY5qi/1B0gWaSjt8cmvKjsvqmJbpEmwTTq1+wIVfJ8KvNUz+aq0Kp" +
+                "spERMDynzaumNSluK3rqCDW3BAkEA9bUIJcz9OasluupCyiKDccvkkVdr8FPRayRabfgUltOqrAEQFMy" +
+                "vRlMui5znIE0OhdzZwtxUhxkpctB4MxQy2QJBAPGipvinjRj9EF2EPAbtovWHJEgoYGIpmCo/bgqGhUf" +
+                "EbPjdQXIiCWjP2umaN8jarKHouRNd2d6unJ/BnTEogb8CQGZtKRBY+9bmebwJm/4XlSQDEy1jfCObTVm" +
+                "Utf3RxQN7CVLavpFtIkP2uRiKN+9HMB6tijmpD7Oh0Z2DOhhQ+0ECQQCCuBlYH1xnjk/SJ31JyjkEVq2" +
+                "8E4vAzvuwr0vaideEcbD6GMgU9HDesMOe6H0RPatyk7G71mPM4e19R4LAW0eFAkAXAEU8Mh96ML7paJ2" +
+                "zbgHW4PzGpYXzLoQQMfvMfZEiPjG0lb6lUbWXddWm9cw+Qh301Mh0cPCmiWqD79xvVYrMA==";
+
 
     public static final String UNCHAINED_PUBLIC_CERT =
             "MIICsDCCAhmgAwIBAgIJANxvwSnbFJp1MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV\n" +


### PR DESCRIPTION
The Base64 for this key is actually invalid. This has been uncovered in
the hub in work to migrate to dropwizard 2. The changes in dependencies
there have meant using a less lenient base64 decoder which is breaking
the tests.